### PR TITLE
Bump version to v22.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=https://github.com/ElementsProject/lightning.git
-ARG VERSION=v0.10.2
+ARG VERSION=v22.11.1
 ARG USER=lightning
 ARG DATA=/data
 


### PR DESCRIPTION
Release notes: https://github.com/ElementsProject/lightning/releases/tag/v22.11.1

Build was successful on `arm64` and `amd64`. To run I had to use `--database-upgrade=true`.